### PR TITLE
fix Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We really like Netlify and S3/Cloudfront ourselves.
 
 ## Limitations
 
-This booking widget is meant to be a simmple example and does not support all different Healthie account settings.
+This booking widget is meant to be a simple example and does not support all different Healthie account settings.
 It has simplified error handling (via Javascript alerts).  
 
 


### PR DESCRIPTION
Hi Healthie,

I was reading your API docs and ended up at this repo. This PR fixes a typo in the Readme.

This widget may be an older sample repo, but it is easy to find from https://docs.gethealthie.com/guides/intro/

Thanks,
-Rex